### PR TITLE
fix: ignore change status when searching command

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,7 +14,8 @@
 - name: Check if systemd is installed
   shell: command -v systemctl >/dev/null 2>&1
   register: is_systemctl_exist
-  ignore_errors: yes
+  ignore_errors: true
+  changed_when: false
 
 - name: Stop and disable systemd service
   systemd:


### PR DESCRIPTION
The role itself stops and disables systemd-resolved. On containers, systemd isn't installed, but on the hosts it will be running on, systemd will likely be installed. This is just a fix to ignore the `changed` = `true` in the idempotency step when it checks for the `systemctl` command. 